### PR TITLE
Add withdrawal tests

### DIFF
--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -540,7 +540,28 @@ class Frontier(BaseFork, solc_name="homestead"):
 
         Frontier does not require pre-allocated accounts
         """
-        return {}
+# contract EmptyRewarder {
+#    fallback() external payable {
+#        assembly {
+#            let ptr := mload(0x40)
+#            mstore(ptr,       0x40)
+#            mstore(add(ptr,32), 0x60)
+#            mstore(add(ptr,64), 0)
+#            mstore(add(ptr,96), 0)
+#            return(ptr, 0x80)
+#        }
+#    }
+# }
+        new_allocation = {
+            # Hardcoded address of the BlockReward contract
+            0x2000000000000000000000000000000000000001: {
+                "nonce": 1,
+                "code": "0x608060408181528152606060a0525f60c081905260e0528080f3fea264697066735822"
+                "1220ad48f9b500787ea20a77467cda4f31efaf4768b15664ca9fb5e0639aea63976e64736f6c6343"
+                "00081e0033"
+            }
+        }
+        return new_allocation | super(Cancun, cls).pre_allocation_blockchain()  # type: ignore
 
 
 class Homestead(Frontier):

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -22,6 +22,7 @@ from ethereum_test_tools import (
     Transaction,
     TransactionException,
     Withdrawal,
+    YulCompiler,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
@@ -721,3 +722,178 @@ def test_withdrawing_to_precompiles(
         ),
     ]
     blockchain_test(pre=pre, post=post, blocks=blocks)
+
+def test_store_withdrawal_values_in_contract(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    yul: YulCompiler,
+):
+    """Test that system transaction calldata is correctly formed."""
+    contract_address = pre.deploy_contract(
+        code=yul(
+            """
+            {
+                let size := calldatasize()
+                let words := div(add(size, 31), 32)
+                for { let i := 0 } lt(i, words) { i := add(i, 1) } {
+                    sstore(i, calldataload(mul(i, 32)))
+                }
+                stop()
+            }
+            """
+        )
+    )
+
+    withdrawal_1 = Withdrawal(
+        index=0,
+        validator_index=0,
+        address=Address(0x0a),
+        amount=0x0c,
+    )
+    withdrawal_2 = Withdrawal(
+        index=0,
+        validator_index=0,
+        address=Address(0x0b),
+        amount=0x0d,
+    )
+
+    blocks = [
+        Block(
+            withdrawals=[withdrawal_1, withdrawal_2],
+        ),
+    ]
+# Function signature
+#
+#    function executeSystemWithdrawals(
+#        uint256 maxFailedWithdrawalsToProcess,
+#        uint64[] amounts,
+#        address[] addresses
+#    )
+#
+# Encoded words:
+# ── selector
+# ── maxFailedWithdrawalsToProcess = 0
+# ── offset to amounts[]  (96 bytes)
+# ── offset to addresses[] (192 bytes)
+# ── amounts.length = 2
+# ── amounts[0]
+# ── amounts[1]
+# ── addresses.length = 2
+# ── addresses[0]
+# ── addresses[1]
+    post = {
+        contract_address: Account(
+            storage={
+                0x00: 0x99face17000000000000000000000000000000000000000000000000000000
+                0x01: 0000000000000000000000000000000000000000000000000000000000000000
+                0x02: 0000000060000000000000000000000000000000000000000000000000000000
+                0x03: 00000000c0000000000000000000000000000000000000000000000000000000
+                0x04: 0000000002000000000000000000000000000000000000000000000000000000
+                0x05: 000000000c000000000000000000000000000000000000000000000000000000
+                0x06: 000000000d000000000000000000000000000000000000000000000000000000
+                0x07: 0000000002000000000000000000000000000000000000000000000000000000
+                0x08: 000000000a000000000000000000000000000000000000000000000000000000
+                0x09: 000000000b000000000000000000000000000000000000000000000000000000
+            }
+        ),
+    }
+
+    blockchain_test(pre=pre, post=post, blocks=blocks)
+
+def test_withdrawal_system_call_reverts(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    yul: YulCompiler,
+):
+    """Test the system contract call reverting."""
+    contract_address = pre.deploy_contract(
+        code=yul(
+            """
+            {
+                revert(0, 0)
+            }
+            """
+        )
+    )
+
+    withdrawal = Withdrawal(
+        index=0,
+        validator_index=0,
+        address=Address(0x01),
+        amount=1,
+    )
+
+    blocks = [
+        Block(
+            withdrawals=[withdrawal],
+        ),
+    ]
+    post = {}
+
+    blockchain_test(pre=pre, post=post, blocks=blocks)
+
+def test_withdrawal_system_call_runs_out_of_gas(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    yul: YulCompiler,
+):
+    """Test the system contract call reverting."""
+    contract_address = pre.deploy_contract(
+        code=yul(
+            """
+            {
+                for { } 1 { } { }
+            }
+            """
+        )
+    )
+
+    withdrawal = Withdrawal(
+        index=0,
+        validator_index=0,
+        address=Address(0x01),
+        amount=1,
+    )
+
+    blocks = [
+        Block(
+            withdrawals=[withdrawal],
+        ),
+    ]
+    post = {}
+
+    blockchain_test(pre=pre, post=post, blocks=blocks)
+
+
+def test_empty_withdrawals_list(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    yul: YulCompiler,
+):
+    """Test that the system contract call is done even if the withdrawal list is empty."""
+    contract_address = pre.deploy_contract(
+        code=yul(
+            """
+            {
+                sstore(0, 1)
+            }
+            """
+        )
+    )
+
+    blocks = [
+        Block(
+            withdrawals=[],
+        ),
+    ]
+    post = {
+        contract_address: Account(
+            storage={
+                0x0: 0x1,
+            }
+        ),
+    }
+
+    blockchain_test(pre=pre, post=post, blocks=blocks)
+
+# TODO: Test with contract not deployed

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -730,18 +730,7 @@ def test_store_withdrawal_values_in_contract(
 ):
     """Test that system transaction calldata is correctly formed."""
     contract_address = pre.deploy_contract(
-        code=yul(
-            """
-            {
-                let size := calldatasize()
-                let words := div(add(size, 31), 32)
-                for { let i := 0 } lt(i, words) { i := add(i, 1) } {
-                    sstore(i, calldataload(mul(i, 32)))
-                }
-                stop()
-            }
-            """
-        )
+        code=Op.SSTORE(0, Op.CALLDATASIZE) + sum(Op.SSTORE(i + 1, Op.CALLDATALOAD(i * 32)) for i in range(10))
     )
 
     withdrawal_1 = Withdrawal(
@@ -807,13 +796,7 @@ def test_withdrawal_system_call_reverts(
 ):
     """Test the system contract call reverting."""
     contract_address = pre.deploy_contract(
-        code=yul(
-            """
-            {
-                revert(0, 0)
-            }
-            """
-        )
+        code=Op.REVERT(0, 0)
     )
 
     withdrawal = Withdrawal(
@@ -839,13 +822,7 @@ def test_withdrawal_system_call_runs_out_of_gas(
 ):
     """Test the system contract call reverting."""
     contract_address = pre.deploy_contract(
-        code=yul(
-            """
-            {
-                for { } 1 { } { }
-            }
-            """
-        )
+        code=Op.INVALID
     )
 
     withdrawal = Withdrawal(
@@ -872,13 +849,7 @@ def test_empty_withdrawals_list(
 ):
     """Test that the system contract call is done even if the withdrawal list is empty."""
     contract_address = pre.deploy_contract(
-        code=yul(
-            """
-            {
-                sstore(0, 1)
-            }
-            """
-        )
+        code=Op.SSTORE(0, 1)
     )
 
     blocks = [


### PR DESCRIPTION
## 🗒️ Description

Adds specific test for Gnosis version of withdrawals following https://github.com/gnosischain/specs/blob/master/execution/withdrawals.md


## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
